### PR TITLE
#16581 - Updated docker and parity version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+LOCALTIME_PATH=~/etc/localtime

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /build
 /node_modules
 package-lock.json
+.env
+parity-assets/keys/DevelopmentNetwork/dapps_history.json
+parity-assets/keys/DevelopmentNetwork/address_book.json
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
- version: '3'
+version: '3'
 networks: # private network of our services
     etherium-network:
 
@@ -14,13 +14,6 @@ services:
     volumes:
       - "${PROJECT_SRC:-.}/:/src"
     working_dir: /src
-    tty: true # interactive mode
-    stdin_open: true # interactive mode
-    command:
-      - 'top'
-    entrypoint:
-      - /bin/sh
-      - -c
 
   bootstrap:
     image: "parity/parity:${DOCKER_PARITY_VER:-v1.9.6}"
@@ -30,13 +23,17 @@ services:
       etherium-network:
         aliases:
           - bootstrap # private host-name in of our network
-
     volumes:
       - "./parity-assets/config.toml:/root/.local/share/io.parity.ethereum/config.toml:ro"
       - "./parity-assets/parity-genesis.json:/root/.local/share/io.parity.ethereum/parity-genesis.json:ro"
       - "./parity-assets/reserved-peers.txt:/root/.local/share/io.parity.ethereum/reserved-peers.txt:ro"
       - "./parity-assets/password:/root/.local/share/io.parity.ethereum/password:ro"
       - "./parity-assets/keys:/root/.local/share/io.parity.ethereum/keys:rw"
-      - "/etc/localtime:/etc/localtime:ro"
-
-    command: --config /root/.local/share/io.parity.ethereum/config.toml --unsafe-expose --node-key 091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322
+      - "${LOCALTIME_PATH:-/etc/localtime}:/etc/localtime:ro"
+    command: --config /root/.local/share/io.parity.ethereum/config.toml --jsonrpc-cors all --unsafe-expose --node-key 091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322
+    ports:
+      - "30303:30303"
+      - "30303:30303/udp"
+      - "8545:8545"
+      - "8546:8546"
+      - "8180:8180"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zap_contracts",
-  "version": "0.1",
+  "version": "0.0.1",
   "description": "Orcales market contracts",
   "main": "truffle migrate",
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,12 @@ To run tests
  - Start development blockchain: truffle develop
  - Start all tests: test
  - Start specified test file: test filename.js
+ 
+To run docker-compose with parity private network
+- Create .env file from .env.example with correct path to yours host localtime file.
+- Run `docker-compose up`  
+- Parity UI: `http://127.0.0.1:8180`
+- Parity Ethereum RPC: `http://127.0.0.1:8545`
 
 Software versions
  - Solidity v0.4.17

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -27,11 +27,17 @@ module.exports = {
             port: 7545,
             network_id: "*" 
         },
-	    docker: {
-            host: "172.18.0.3",
+	docker: {
+            host: "bootstrap",
             port: 8545,
             network_id: "*",
             from: "0x010e49e47cbb34e67c072702ed6f4d8b273f751f"// must be first account in accounts[] array inside tests
-    	}
+    	},
+        "docker-local": {
+            host: "127.0.0.1",
+            port: 8545,
+            network_id: "*",
+            from: "0x010e49e47cbb34e67c072702ed6f4d8b273f751f"// must be first account in accounts[] array inside tests
+        }
     }
 };


### PR DESCRIPTION
@zwalla  Added local opened ports for parity instance so you could migrate and manipulate contracts in parity private network from the host.

Please, don't forget to create .env with the correct reference to local time file. It depends on host os. On mac os I've created symlink for /etc/localtime and added ~/etc/locatime path to docker-compose.